### PR TITLE
Update iso14443a_uid.pde

### DIFF
--- a/PN532/examples/iso14443a_uid/iso14443a_uid.pde
+++ b/PN532/examples/iso14443a_uid/iso14443a_uid.pde
@@ -29,6 +29,9 @@
   #include <Wire.h>
   #include <PN532_I2C.h>
   #include <PN532.h>
+  
+  PN532_I2C pn532i2c(Wire);
+  PN532 nfc(pn532i2c);
 #endif
   
 void setup(void) {


### PR DESCRIPTION
The instantiation of nfc was removed so this file won't run in I2C without this edit.
