### PR TITLE
add {read|write}Register functions

### DIFF
--- a/PN532/PN532.cpp
+++ b/PN532/PN532.cpp
@@ -143,6 +143,66 @@ uint32_t PN532::getFirmwareVersion(void)
 
 /**************************************************************************/
 /*!
+    @brief  Read a PN532 register
+
+    @returns  The register value.
+*/
+/**************************************************************************/
+uint32_t PN532::readRegister(uint16_t reg)
+{
+    uint32_t response;
+
+    pn532_packetbuffer[0] = PN532_COMMAND_READREGISTER;
+    pn532_packetbuffer[1] = (reg >> 8) & 0xFF;
+    pn532_packetbuffer[2] = reg & 0xFF;
+
+    if (HAL(writeCommand)(pn532_packetbuffer, 3)) {
+        return 0;
+    }
+
+    // read data packet
+    int16_t status = HAL(readResponse)(pn532_packetbuffer, sizeof(pn532_packetbuffer));
+    if (0 > status) {
+        return 0;
+    }
+
+    response = pn532_packetbuffer[0];
+
+    return response;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Read a PN532 register
+
+    @returns  The register value.
+*/
+/**************************************************************************/
+uint32_t PN532::writeRegister(uint16_t reg, uint8_t val)
+{
+    uint32_t response;
+
+    pn532_packetbuffer[0] = PN532_COMMAND_WRITEREGISTER;
+    pn532_packetbuffer[1] = (reg >> 8) & 0xFF;
+    pn532_packetbuffer[2] = reg & 0xFF;
+    pn532_packetbuffer[3] = val;
+
+
+    if (HAL(writeCommand)(pn532_packetbuffer, 4)) {
+        return 0;
+    }
+
+    // read data packet
+    int16_t status = HAL(readResponse)(pn532_packetbuffer, sizeof(pn532_packetbuffer));
+    if (0 > status) {
+        return 0;
+    }
+
+    return 1;
+}
+
+/**************************************************************************/
+/*!
     Writes an 8-bit value that sets the state of the PN532's GPIO pins
 
     @warning This function is provided exclusively for board testing and

--- a/PN532/PN532.cpp
+++ b/PN532/PN532.cpp
@@ -143,7 +143,9 @@ uint32_t PN532::getFirmwareVersion(void)
 
 /**************************************************************************/
 /*!
-    @brief  Read a PN532 register
+    @brief  Read a PN532 register.
+
+    @param  reg  the 16-bit register address.
 
     @returns  The register value.
 */
@@ -173,9 +175,12 @@ uint32_t PN532::readRegister(uint16_t reg)
 
 /**************************************************************************/
 /*!
-    @brief  Read a PN532 register
+    @brief  Write to a PN532 register.
 
-    @returns  The register value.
+    @param  reg  the 16-bit register address.
+    @param  val  the 8-bit value to write.
+
+    @returns  0 for failure, 1 for success.
 */
 /**************************************************************************/
 uint32_t PN532::writeRegister(uint16_t reg, uint8_t val)

--- a/PN532/PN532.h
+++ b/PN532/PN532.h
@@ -134,6 +134,8 @@ public:
     // Generic PN532 functions
     bool SAMConfig(void);
     uint32_t getFirmwareVersion(void);
+    uint32_t readRegister(uint16_t reg);
+    uint32_t writeRegister(uint16_t reg, uint8_t val);
     bool writeGPIO(uint8_t pinstate);
     uint8_t readGPIO(void);
     bool setPassiveActivationRetries(uint8_t maxRetries);


### PR DESCRIPTION
For some advanced usage scenarios, it's necessary to read/write PN532 low-level registers directly. These functions allow this.