### PR TITLE
Switch On/Off the RF field for power savings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/PN532/PN532.cpp
+++ b/PN532/PN532.cpp
@@ -334,6 +334,36 @@ bool PN532::setPassiveActivationRetries(uint8_t maxRetries)
     return (0 < HAL(readResponse)(pn532_packetbuffer, sizeof(pn532_packetbuffer)));
 }
 
+/**************************************************************************/
+/*!
+    Sets the RFon/off uint8_t of the RFConfiguration register
+
+    @param  autoRFCA    0x00 No check of the external field before 
+                        activation, 0x02 Check the external field
+
+    @param  rFOnOff     0x00 Switch the RF field off, 0x01 switch the RF 
+                        field on
+
+    @returns    1 if everything executed properly, 0 for an error
+*/
+/**************************************************************************/
+
+bool PN532::setRFField(uint8_t autoRFCA, uint8_t rFOnOff)
+{
+    pn532_packetbuffer[0] = PN532_COMMAND_RFCONFIGURATION;
+    pn532_packetbuffer[1] = 1;
+    pn532_packetbuffer[2] = 0x00 | autoRFCA | rFOnOff;  
+
+    if (HAL(writeCommand)(pn532_packetbuffer, 3)) {
+        return 0x0;  // command failed
+    }
+
+    // read data packet
+    if (HAL(readResponse)(pn532_packetbuffer, sizeof(pn532_packetbuffer), timeout) < 0) {
+        return 0x0;
+    }
+}
+
 /***** ISO14443A Commands ******/
 
 /**************************************************************************/

--- a/PN532/PN532.cpp
+++ b/PN532/PN532.cpp
@@ -339,7 +339,10 @@ bool PN532::setPassiveActivationRetries(uint8_t maxRetries)
     Sets the RFon/off uint8_t of the RFConfiguration register
 
     @param  autoRFCA    0x00 No check of the external field before 
-                        activation, 0x02 Check the external field
+                        activation 
+                        
+                        0x02 Check the external field before 
+                        activation
 
     @param  rFOnOff     0x00 Switch the RF field off, 0x01 switch the RF 
                         field on

--- a/PN532/PN532.cpp
+++ b/PN532/PN532.cpp
@@ -358,10 +358,7 @@ bool PN532::setRFField(uint8_t autoRFCA, uint8_t rFOnOff)
         return 0x0;  // command failed
     }
 
-    // read data packet
-    if (HAL(readResponse)(pn532_packetbuffer, sizeof(pn532_packetbuffer), timeout) < 0) {
-        return 0x0;
-    }
+    return (0 < HAL(readResponse)(pn532_packetbuffer, sizeof(pn532_packetbuffer)));
 }
 
 /***** ISO14443A Commands ******/

--- a/PN532/PN532.h
+++ b/PN532/PN532.h
@@ -139,6 +139,7 @@ public:
     bool writeGPIO(uint8_t pinstate);
     uint8_t readGPIO(void);
     bool setPassiveActivationRetries(uint8_t maxRetries);
+    bool setRFField(uint8_t autoRFCA, uint8_t rFOnOff);
 
     /**
     * @brief    Init PN532 as a target


### PR DESCRIPTION
This function allows the host controller to have more control over the power management of the chipset PN532. The new function switch on/off the RF filed with some options.