### PR TITLE
fix PN532 example in I2C mode

### DIFF
--- a/PN532/examples/readMifare/readMifare.pde
+++ b/PN532/examples/readMifare/readMifare.pde
@@ -37,6 +37,8 @@
   #include <Wire.h>
   #include <PN532_I2C.h>
   #include <PN532.h>
+  PN532_I2C pn532i2c(Wire);
+  PN532 nfc(pn532i2c);	
 #endif
 void setup(void) {
   Serial.begin(115200);


### PR DESCRIPTION
Fixed PN532 example missing of PN532 I2C mode constructor. 